### PR TITLE
set refspec based on GITHUB_REF when PUSH_ALL_REFS falsy

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,6 @@ else
         echo "FATAL: You must upgrade to using actions inputs instead of args: to push a single branch" > /dev/stderr
         exit 1
     else
-        eval git push -u ${GIT_PUSH_ARGS} mirror
+        eval git push -u ${GIT_PUSH_ARGS} mirror "${GITHUB_REF}"
     fi
 fi


### PR DESCRIPTION
Hello!

This PR hopefully closes #15.
I have added testing [this workflow](https://github.com/skarzi/mirror-action/blob/skarzi-master/.github/workflows/tests.yml) in my fork and 2 test cases on the following branches:

+ https://github.com/skarzi/mirror-action/tree/test/issue-15/new-branch - new branch created
+ https://github.com/skarzi/mirror-action/tree/test/issue-15/new-tag - new tag created and `GIT_PUSH_ARGS` set to `--force --prune` (so `--tags` removed because I wanted to test if pushing a single tag works like expected)