### PR TITLE
Fix known_hosts not working (#14)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ if [[ "${GIT_SSH_PRIVATE_KEY}" != "" ]]; then
     chmod 600 ~/.ssh/id_rsa
     if [[ "${GIT_SSH_KNOWN_HOSTS}" != "" ]]; then
       echo "${GIT_SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
-      git config --global core.sshCommand "ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=~/.ssh/known_hosts"
+      git config --global core.sshCommand "ssh -i /github/home/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/github/home/.ssh/known_hosts"
     else
       if [[ "${GIT_SSH_NO_VERIFY_HOST}" != "true" ]]; then
         echo "WARNING: no known_hosts set and host verification is enabled (the default)"
@@ -53,7 +53,7 @@ if [[ "${GIT_SSH_PRIVATE_KEY}" != "" ]]; then
         echo "Please either provide the GIT_SSH_KNOWN_HOSTS or GIT_SSH_NO_VERIFY_HOST inputs"
         exit 1
       else
-        git config --global core.sshCommand "ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+        git config --global core.sshCommand "ssh -i /github/home/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
       fi
     fi
 else


### PR DESCRIPTION
### Use absolute path for git config options

Replace `~` with `/github/home` when used for a file path in the options of a git configuration. For some reason, git does not resolve it and ignores the errors (probably just defaults too) as the files do not exist.
Passing it `~/.ssh/id_rsa` was not an issue though as it already is the default private key file ssh uses.

### Tested and approved

I temporarily published it to the actions marketplace in order to try it with my non-working workflow and it fixed it.