### PR TITLE
Fix known_hosts not working in a reliable way

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,8 +47,9 @@ if [[ "${GIT_SSH_PRIVATE_KEY}" != "" ]]; then
     fi
     chmod 600 ~/.ssh/id_rsa
     if [[ "${GIT_SSH_KNOWN_HOSTS}" != "" ]]; then
-      echo "${GIT_SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
-      git config --global core.sshCommand "ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=~/.ssh/known_hosts"
+      KNOWN_HOSTS_FILE=~/.ssh/known_hosts
+      echo "${GIT_SSH_KNOWN_HOSTS}" > "${KNOWN_HOSTS_FILE}"
+      git config --global core.sshCommand "ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=${KNOWN_HOSTS_FILE}"
     else
       if [[ "${GIT_SSH_NO_VERIFY_HOST}" != "true" ]]; then
         echo "WARNING: no known_hosts set and host verification is enabled (the default)"


### PR DESCRIPTION
This fixes the issue of the `GIT_SSH_KNOWN_HOSTS` option not working taking into account suggestions on how to resolve this from #19.

### Underlying issue:

In the shell the home directory is resolved to `/github/home`, but when ssh resolves it, it resolves to `/root`.
This causes the default search paths to be wrong (`/root/.ssh/known_hosts` instead of `/github/home/.ssh/known_hosts`), hence the paths need to be explicitly specified.
The idenity file path is automatically expanded by the shell because it's an argument on it's own. That's why `-i ~/.ssh/id_rsa` is working. But for the known hosts file path this is not the case because the argument is an assignment, so the shell doesn't expand it.
To prevent this from breaking if GitHub changes the home path `~/.ssh/known_hosts` is expanded and saved into a variable (`KNOWN_HOSTS_FILE`) which then is used for saving the know_hosts file and for configuring ssh.

This was suggested to the author of #19 but they never updated the pull requests hence I made a new one.

closes: #14
supersedeas: #19